### PR TITLE
Adjust tooltip position for left and right buttons in toolbar

### DIFF
--- a/src/MoreActionsPopover.tsx
+++ b/src/MoreActionsPopover.tsx
@@ -62,7 +62,7 @@ const MoreActionsPopover: React.FC<MoreActionsPopoverProps> = ({
     const renderMoreActions = () => (<div style={{ padding: '8px' }}>{l10n.toolbar.moreActions}</div>);
     const renderTarget = (toggle: Toggle, opened: boolean) => (
         <Tooltip
-            position={Position.BottomCenter}
+            position={Position.BottomRight}
             target={<Button onClick={toggle} isSelected={opened}><MoreIcon /></Button>}
             content={renderMoreActions}
             offset={PORTAL_OFFSET}

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -214,7 +214,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
         ),
         toggleSidebarButton: (
             <Tooltip
-                position={Position.BottomCenter}
+                position={Position.BottomLeft}
                 target={(
                     <Button onClick={toggleSidebar} isSelected={isSidebarOpened}>
                         <LeftSidebarIcon />


### PR DESCRIPTION
fix #43 

<img width="268" alt="Screen Shot 2020-03-04 at 22 56 07" src="https://user-images.githubusercontent.com/57786711/75897753-a6225180-5e6b-11ea-8b2d-4886ca53d5ac.png">
<img width="233" alt="Screen Shot 2020-03-04 at 22 56 47" src="https://user-images.githubusercontent.com/57786711/75897757-a7ec1500-5e6b-11ea-9680-fc8c91e6e26b.png">
