### PR TITLE
The default scale can be a special zoom level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,16 @@ const renderPage: RenderPage = (props: RenderPageProps) => (
 />
 ~~~
 
+**Improvement**
+- The default scale can be a special zoom level. For example, we can fit page in the container initially:
+
+~~~ javascript
+<Viewer
+    fileUrl='/path/to/document.pdf'
+    defaultScale={SpecialZoomLevel.PageFit}
+/>
+~~~
+
 ## v1.4.0
 
 **New features**

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,3 @@
+# License
+
+You have to purchase a Commercial License at the [official website](https://react-pdf-viewer.dev).

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ __Coming soon__
 * [ ] Theming
 * [ ] Darkmode
 
+## License
+
+You have to purchase a Commercial License at the [official website](https://react-pdf-viewer.dev).
+
 ## Usage
 
 Perform the following steps to have the simplest example. For more demos, please look at the [demo](/demo) folder.
@@ -97,9 +101,6 @@ It will check if the entire source code compatible with
 * [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react)
 * [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint)
 
-## License
-Purchase a Commercial License at the [official website](https://react-pdf-viewer.dev)
-
 ## About
 
 This project is developed by [Nguyen Huu Phuoc](https://twitter.com/nghuuphuoc).
@@ -111,4 +112,5 @@ You might be interesting in my projects:
 | [CSS Layout](https://csslayout.io)                | A collection of popular layouts and patterns made with CSS        |
 | [Fake Numbers](https://fakenumbers.io)            | Generate fake and valid numbers                                   |
 | [Form Validation](https://formvalidation.io)      | The best validation library for JavaScript                        |
+| [HTML DOM](https://htmldom.dev)                   | How to manage HTML DOM with vanilla JavaScript                    |
 | [React PDF Viewer](https://react-pdf-viewer.dev)  | A React component to view a PDF document                          |

--- a/demo/latest/src/App.tsx
+++ b/demo/latest/src/App.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import Viewer, { Worker } from '@phuocng/react-pdf-viewer';
+import { Worker } from '@phuocng/react-pdf-viewer';
 
 import '@phuocng/react-pdf-viewer/cjs/react-pdf-viewer.css';
-import SvgLayerExample from './SvgLayerExample';
+import SinglePageViewExample from './SinglePageViewExample';
 
 const App = () => {
     return (
         <Worker workerUrl="https://unpkg.com/pdfjs-dist@2.2.228/build/pdf.worker.min.js">
             <div style={{ height: '750px', padding: '16px 0' }}>
-                <SvgLayerExample
+                <SinglePageViewExample
                     fileUrl="/pdf-open-parameters.pdf"
                 />
             </div>

--- a/demo/latest/src/SinglePageViewExample.tsx
+++ b/demo/latest/src/SinglePageViewExample.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Viewer, { SpecialZoomLevel } from '@phuocng/react-pdf-viewer';
+
+interface SinglePageViewExampleProps {
+    fileUrl: string;
+}
+
+const SinglePageViewExample: React.FC<SinglePageViewExampleProps> = ({ fileUrl }) => {
+    return (
+        <Viewer
+            fileUrl={fileUrl}
+            defaultScale={SpecialZoomLevel.PageFit}
+        />
+    );
+};
+
+export default SinglePageViewExample;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -250,7 +250,7 @@ export interface ViewerProps {
     // The default zoom level
     // If it's not set, the initial zoom level will be calculated based on the dimesion of page and the container width
     // So that, the document will fit best within the container
-    defaultScale?: number;
+    defaultScale?: number | SpecialZoomLevel;
     fileUrl: string;
     // The page (zero-index based) that will be displayed initially
     initialPage?: number;

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -43,7 +43,7 @@ type RenderViewerType = (props: RenderViewerProps) => React.ReactElement;
 interface ViewerProps {
     // The default zoom level
     // If it's not set, the initial zoom level will be calculated based on the dimesion of page and the container width
-    defaultScale?: number;
+    defaultScale?: number | SpecialZoomLevel;
     fileUrl: string;
     // The page (zero-index based) that will be displayed initially
     initialPage?: number;
@@ -105,10 +105,10 @@ const Viewer: React.FC<ViewerProps> = ({
     const renderDoc = (renderViewer: RenderViewer) => (doc: PdfJs.PdfDocument) => {
         const renderInner = (ps: PageSize) => {
             const pageSize = ps;
-            pageSize.scale = defaultScale || ps.scale;
 
             return (
                 <Inner
+                    defaultScale={defaultScale}
                     doc={doc}
                     file={file}
                     initialPage={initialPage}

--- a/src/layouts/Inner.tsx
+++ b/src/layouts/Inner.tsx
@@ -41,6 +41,7 @@ const SCROLL_BAR_WIDTH = 17;
 const PAGE_PADDING = 8;
 
 interface InnerProps {
+    defaultScale?: number | SpecialZoomLevel;
     doc: PdfJs.PdfDocument;
     file: File;
     initialPage?: number;
@@ -56,7 +57,7 @@ interface InnerProps {
 }
 
 const Inner: React.FC<InnerProps> = ({
-    doc, file, initialPage, keyword, layout, pageSize, render, renderPage, selectionMode,
+    defaultScale, doc, file, initialPage, keyword, layout, pageSize, render, renderPage, selectionMode,
     onDocumentLoad, onOpenFile, onZoom,
 }) => {
     const theme = React.useContext(ThemeContent);
@@ -134,12 +135,6 @@ const Inner: React.FC<InnerProps> = ({
         toggleDragScroll(mode === SelectionMode.Hand);
         setCurrentMode(mode);
     };
-    React.useEffect(() => {
-        // Toggle the drag scroll if the hand tool is set initially
-        if (selectionMode === SelectionMode.Hand) {
-            toggleDragScroll(true);
-        }
-    }, []);
 
     const download = (): void => {
         downloadFile(file.name, file.data);
@@ -175,6 +170,17 @@ const Inner: React.FC<InnerProps> = ({
         setScale(scaled);
         onZoom(doc, scaled);
     };
+
+    React.useEffect(() => {
+        // Toggle the drag scroll if the hand tool is set initially
+        if (selectionMode === SelectionMode.Hand) {
+            toggleDragScroll(true);
+        }
+        // If the default scale is set
+        if (defaultScale) {
+            zoom(defaultScale);
+        }
+    }, []);
 
     const pageVisibilityChanged = (pageIndex: number, ratio: number): void => {
         pageVisibility[pageIndex] = ratio;


### PR DESCRIPTION
for #88 

~~~ javascript
<Viewer
    fileUrl='/path/to/document.pdf'
    defaultScale={SpecialZoomLevel.PageFit}
/>
~~~

<img width="1048" alt="Screen Shot 2020-03-29 at 17 09 29" src="https://user-images.githubusercontent.com/57786711/77846424-2aa08f80-71e0-11ea-8785-4ada2a996d9e.png">
