### PR TITLE
feat: Customize error renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@
 The annotation layer is rewritten. Support the following type of annotations:
 - Link
 
+- Customize error renderer.
+
+~~~ javascript
+const renderError = (error: LoadError) => {
+    let message = '';
+    switch (error.name) {
+        case 'InvalidPDFException':
+            message = 'The document is invalid or corrupted';
+            break;
+        case 'MissingPDFException':
+            message = 'The document is missing';
+            break;
+        case 'UnexpectedResponseException':
+            message = 'Unexpected server response';
+            break;
+        default:
+            message = 'Cannot load the document';
+            break;
+    }
+
+    return (<div>{message}</div>);
+};
+
+<Viewer
+    fileUrl={fileUrl}
+    renderError={renderError}
+/>
+~~~
+
 **Bug fix**
 - The canvas layer is blurry
 - The tooltip, popover positions are not correct in some cases

--- a/demo/latest/src/App.tsx
+++ b/demo/latest/src/App.tsx
@@ -2,12 +2,13 @@ import React from 'react';
 import Viewer, { Worker } from '@phuocng/react-pdf-viewer';
 
 import '@phuocng/react-pdf-viewer/cjs/react-pdf-viewer.css';
+import RenderErrorExample from './RenderErrorExample';
 
 const App = () => {
     return (
         <Worker workerUrl="https://unpkg.com/pdfjs-dist@2.2.228/build/pdf.worker.min.js">
             <div style={{ height: '750px', padding: '16px 0' }}>
-                <Viewer fileUrl="/pdf-open-parameters.pdf" />
+                <RenderErrorExample fileUrl="/pdf-open-parameters1.pdf" />
             </div>
         </Worker>
     );

--- a/demo/latest/src/RenderErrorExample.tsx
+++ b/demo/latest/src/RenderErrorExample.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import Viewer, { LoadError } from '@phuocng/react-pdf-viewer';
+
+interface RenderErrorExampleProps {
+    fileUrl: string;
+}
+
+const RenderErrorExample: React.FC<RenderErrorExampleProps> = ({ fileUrl }) => {
+    const renderError = (error: LoadError) => {
+        let message = '';
+        switch (error.name) {
+            case 'InvalidPDFException':
+                message = 'The document is invalid or corrupted';
+                break;
+            case 'MissingPDFException':
+                message = 'The document is missing';
+                break;
+            case 'UnexpectedResponseException':
+                message = 'Unexpected server response';
+                break;
+            default:
+                message = 'Cannot load the document';
+                break;
+        }
+
+        return (
+            <div
+                style={{
+                    alignItems: 'center',
+                    display: 'flex',
+                    justifyContent: 'center'
+                }}
+            >
+                <div
+                    style={{
+                        backgroundColor: '#e53e3e',
+                        borderRadius: '0.25rem',
+                        color: '#fff',
+                        padding: '0.5rem',
+                    }}
+                >
+                    {message}
+                </div>
+            </div>
+        );
+    };
+
+    return (
+        <Viewer
+            fileUrl={fileUrl}
+            renderError={renderError}
+        />
+    );
+};
+
+export default RenderErrorExample;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -216,6 +216,21 @@ export interface RenderViewerProps {
 }
 export type RenderViewer = (props: RenderViewerProps) => React.ReactElement;
 
+// Represents the error in case the document can't be loaded
+export interface LoadError {
+    message?: string;
+    // Some possible values for `name` are
+    // - AbortException
+    // - FormatError
+    // - InvalidPDFException
+    // - MissingPDFException
+    // - PasswordException
+    // - UnexpectedResponseException
+    // - UnknownErrorException
+    name?: string;
+}
+export type RenderError = (error: LoadError) => React.ReactElement;
+
 export interface RenderPageProps {
     annotationLayer: Slot;
     canvasLayer: Slot;
@@ -261,6 +276,7 @@ export interface ViewerProps {
     // The prefix for CSS classes
     prefixClass?: string;
     render?: RenderViewer;
+    renderError?: RenderError;
     renderPage?: RenderPage;
     selectionMode?: SelectionMode;
     onDocumentLoad?(doc: PdfJs.PdfDocument): void;

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -17,7 +17,7 @@ import { Layout } from './layouts/Layout';
 import PageSizeCalculator, { PageSize } from './layouts/PageSizeCalculator';
 import { RenderPage } from './layouts/RenderPage';
 import { RenderToolbar } from './layouts/ToolbarSlot';
-import DocumentLoader from './loader/DocumentLoader';
+import DocumentLoader, { RenderError } from './loader/DocumentLoader';
 import LocalizationMap from './localization/LocalizationMap';
 import LocalizationProvider from './localization/LocalizationProvider';
 import ScrollMode from './ScrollMode';
@@ -54,6 +54,7 @@ interface ViewerProps {
     // The prefix for CSS classes
     prefixClass?: string;
     render?: RenderViewerType;
+    renderError?: RenderError;
     renderPage?: RenderPage;
     // The text selection mode
     selectionMode?: SelectionMode;
@@ -70,6 +71,7 @@ const Viewer: React.FC<ViewerProps> = ({
     localization,
     prefixClass,
     render,
+    renderError,
     renderPage,
     selectionMode = SelectionMode.Text,
     onDocumentLoad = () => {/**/},
@@ -139,6 +141,7 @@ const Viewer: React.FC<ViewerProps> = ({
                 <DocumentLoader
                     file={file.data}
                     render={renderDoc(defaultRenderer)}
+                    renderError={renderError}
                 />
             </LocalizationProvider>
         </ThemeProvider>

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import defaultLayout from './layouts/defaultLayout';
 import defaultToolbar from './layouts/defaultToolbar';
 import { default as ISlot } from './layouts/Slot';
 import { default as IToolbarSlot, RenderToolbar as RenderToolbarType, RenderToolbarSlot as RenderToolbarSlotType } from './layouts/ToolbarSlot';
+import { RenderError as RenderErrorType } from './loader/DocumentLoader';
 import { default as ILocalizationMap } from './localization/LocalizationMap';
 import Modal from './portal/Modal';
 import Popover from './portal/Popover';
@@ -52,6 +53,7 @@ export {
     Worker,
 };
 export type LocalizationMap = ILocalizationMap;
+export type RenderError = RenderErrorType;
 export type RenderToolbar = RenderToolbarType;
 export type RenderToolbarSlot = RenderToolbarSlotType;
 export type Slot = ISlot;

--- a/src/loader/FailureState.ts
+++ b/src/loader/FailureState.ts
@@ -6,12 +6,13 @@
  * @copyright 2019-2020 Nguyen Huu Phuoc <me@phuoc.ng>
  */
 
+import LoadError from './LoadError';
 import LoadingStatus from './LoadingStatus';
 
 class FailureState extends LoadingStatus {
-    public error: string;
+    public error: LoadError;
 
-    constructor(error: string) {
+    constructor(error: LoadError) {
         super();
         this.error = error;
     }

--- a/src/loader/LoadError.ts
+++ b/src/loader/LoadError.ts
@@ -1,0 +1,23 @@
+/**
+ * A React component to view a PDF document
+ *
+ * @see https://react-pdf-viewer.dev
+ * @license https://react-pdf-viewer.dev/license
+ * @copyright 2019-2020 Nguyen Huu Phuoc <me@phuoc.ng>
+ */
+
+ // Represents the error in case the document can't be loaded
+interface LoadError {
+    message?: string;
+    // Some possible values for `name` are
+    // - AbortException
+    // - FormatError
+    // - InvalidPDFException
+    // - MissingPDFException
+    // - PasswordException
+    // - UnexpectedResponseException
+    // - UnknownErrorException
+    name?: string;
+}
+
+export default LoadError;


### PR DESCRIPTION
fix #65 

<img width="827" alt="Screen Shot 2020-04-26 at 21 50 09" src="https://user-images.githubusercontent.com/57786711/80311178-61ca8680-8808-11ea-9509-ab473d2e072c.png">

~~~ javascript
const renderError = (error: LoadError) => {
    let message = '';
    switch (error.name) {
        case 'InvalidPDFException':
            message = 'The document is invalid or corrupted';
            break;
        case 'MissingPDFException':
            message = 'The document is missing';
            break;
        case 'UnexpectedResponseException':
            message = 'Unexpected server response';
            break;
        default:
            message = 'Cannot load the document';
            break;
    }

    return (<div>{message}</div>);
};

<Viewer
    fileUrl={fileUrl}
    renderError={renderError}
/>
~~~