### PR TITLE
fix: The drag zone isn't visible if the main area is scrolled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## v1.6.0 (not released yet)
 
-**New feature**
-The annotation layer is rewritten. Support the following type of annotations:
-- Link
+**New features**
+
+- The annotation layer is rewritten. Support the following type of annotations:
+    * Link
 
 - Customize error renderer.
 
@@ -35,9 +36,10 @@ const renderError = (error: LoadError) => {
 />
 ~~~
 
-**Bug fix**
+**Bug fixes**
 - The canvas layer is blurry
 - The tooltip, popover positions are not correct in some cases
+- The drag zone isn't visible if the main area is scrolled
 
 ## v1.5.0
 

--- a/src/layouts/Inner.tsx
+++ b/src/layouts/Inner.tsx
@@ -288,9 +288,6 @@ const Inner: React.FC<InnerProps> = ({
             {
                 attrs: {
                     ref: pagesRef,
-                    style: {
-                        position: 'relative',
-                    },
                 },
                 children: (
                     <>

--- a/src/open/dropArea.less
+++ b/src/open/dropArea.less
@@ -19,6 +19,6 @@
     left: 0px;
     position: absolute;
     right: 0px;
-    top: 0px;
+    top: 44px;
     z-index: 9999;
 }


### PR DESCRIPTION
fix #33 

<img width="1047" alt="Screen Shot 2020-04-27 at 21 30 48" src="https://user-images.githubusercontent.com/57786711/80384261-dbc54300-88ce-11ea-96a4-1ee6eefa733c.png">
