### PR TITLE
fix: The viewer doesn't jump to the destination or searching result exactly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ const handlePageChange = (e: PageChangeEvent) => {
 />
 ~~~
 
+**Bug fixes**
+
+- The viewer doesn't jump to the destination or searching result exactly
+
 **Breaking changes**
 
 The parameters of `onDocumentLoad` and `onZoom` are changed as following:

--- a/src/layouts/Inner.tsx
+++ b/src/layouts/Inner.tsx
@@ -315,6 +315,10 @@ const Inner: React.FC<InnerProps> = ({
             {
                 attrs: {
                     ref: pagesRef,
+                    style: {
+                        // We need this to jump between destinations or searching results
+                        position: 'relative',
+                    }
                 },
                 children: (
                     <>


### PR DESCRIPTION
for #165 

![search](https://user-images.githubusercontent.com/57786711/84589849-b6c76800-ae5b-11ea-8283-b8ff63c98003.gif)
