### PR TITLE
feat: Support non-latin characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ const handlePageChange = (e: PageChangeEvent) => {
 />
 ~~~
 
+- Support non-latin characters via the `characterMap` option
+
+~~~ javascript
+import Viewer, { CharacterMap } from '@phuocng/react-pdf-viewer';
+
+const characterMap: CharacterMap = {
+    isCompressed: true,
+    url: 'https://unpkg.com/pdfjs-dist@2.4.456/cmaps/',
+};
+
+<Viewer
+    characterMap={characterMap}
+    fileUrl='/path/to/document.pdf'
+/>
+~~~
+
 **Bug fixes**
 
 - The viewer doesn't jump to the destination or searching result exactly
@@ -27,10 +43,10 @@ const handlePageChange = (e: PageChangeEvent) => {
 
 The parameters of `onDocumentLoad` and `onZoom` are changed as following:
 
-| v1.6.0                    | v1.7.0                                |
-|---------------------------|---------------------------------------|
-| `onDocumentLoad(doc)`     | `onDocumentLoad({ doc } )`            |
-| `onZoom(doc, scale)`      | `onDocumentLoad({ doc, scale })`      |
+| v1.6.0                | v1.7.0                            |
+|-----------------------|-----------------------------------|
+| `onDocumentLoad(doc)` | `onDocumentLoad({ doc })`         |
+| `onZoom(doc, scale)`  | `onDocumentLoad({ doc, scale })`  |
 
 ## v1.6.0
 

--- a/demo/character-map/CharacterMapExample.tsx
+++ b/demo/character-map/CharacterMapExample.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Viewer, { CharacterMap } from '@phuocng/react-pdf-viewer';
+
+interface CharacterMapExampleProps {
+    fileUrl: string;
+}
+
+const CharacterMapExample: React.FC<CharacterMapExampleProps> = ({ fileUrl }) => {
+    const characterMap: CharacterMap = {
+        isCompressed: true,
+        url: 'https://unpkg.com/pdfjs-dist@2.4.456/cmaps/',
+    };
+
+    return (
+        <div style={{ height: '750px', padding: '16px 0' }}>
+            <Viewer
+                characterMap={characterMap}
+                fileUrl={fileUrl}
+            />
+        </div>
+    );
+};
+
+export default CharacterMapExample;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -280,7 +280,15 @@ export interface ZoomEvent {
     scale: number;
 }
 
+// The character maps that can be downloaded from 
+// https://github.com/mozilla/pdfjs-dist/tree/master/cmaps
+export interface CharacterMap {
+    isCompressed: boolean;
+    url: string;
+}
+
 export interface ViewerProps {
+    characterMap?: CharacterMap;
     // The default zoom level
     // If it's not set, the initial zoom level will be calculated based on the dimesion of page and the container width
     // So that, the document will fit best within the container

--- a/src/Viewer.tsx
+++ b/src/Viewer.tsx
@@ -50,10 +50,15 @@ export interface ZoomEvent {
     doc: PdfJs.PdfDocument;
     scale: number;
 }
+export interface CharacterMap {
+    isCompressed: boolean;
+    url: string;
+}
 
 export type RenderViewer = (props: RenderViewerProps) => React.ReactElement;
 
 interface ViewerProps {
+    characterMap?: CharacterMap;
     // The default zoom level
     // If it's not set, the initial zoom level will be calculated based on the dimesion of page and the container width
     defaultScale?: number | SpecialZoomLevel;
@@ -77,6 +82,7 @@ interface ViewerProps {
 }
 
 const Viewer: React.FC<ViewerProps> = ({
+    characterMap,
     defaultScale,
     fileUrl,
     initialPage,
@@ -162,6 +168,7 @@ const Viewer: React.FC<ViewerProps> = ({
         <ThemeProvider prefixClass={prefixClass}>
             <LocalizationProvider localization={localization}>
                 <DocumentLoader
+                    characterMap={characterMap}
                     file={file.data}
                     render={renderDoc(defaultRenderer)}
                     renderError={renderError}

--- a/src/Worker.tsx
+++ b/src/Worker.tsx
@@ -14,7 +14,7 @@ interface WorkerProps {
     workerUrl: string;
 }
 
-const Worker: React.FC<WorkerProps> = ({ children, workerUrl}) => {
+const Worker: React.FC<WorkerProps> = ({ children, workerUrl }) => {
     PdfJs.GlobalWorkerOptions.workerSrc = workerUrl;
     return <>{children}</>;
 };

--- a/src/annotations/useTogglePopup.ts
+++ b/src/annotations/useTogglePopup.ts
@@ -6,7 +6,7 @@
  * @copyright 2019-2020 Nguyen Huu Phuoc <me@phuoc.ng>
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import useToggle, { ToggleStatus } from '../hooks/useToggle';
 

--- a/src/hooks/useKeyUp.ts
+++ b/src/hooks/useKeyUp.ts
@@ -6,7 +6,7 @@
  * @copyright 2019-2020 Nguyen Huu Phuoc <me@phuoc.ng>
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 const useKeyUp = (targetKeyCode: number, handler: () => void): void => {
     const keyUpHandler = (e: KeyboardEvent): void => {

--- a/src/hooks/useLockScroll.ts
+++ b/src/hooks/useLockScroll.ts
@@ -6,7 +6,7 @@
  * @copyright 2019-2020 Nguyen Huu Phuoc <me@phuoc.ng>
  */
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 const useLockScroll = (): void => {
     useEffect(() => {

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -6,7 +6,7 @@
  * @copyright 2019-2020 Nguyen Huu Phuoc <me@phuoc.ng>
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 enum ToggleStatus {
     Close = 'Close',

--- a/src/loader/DocumentLoader.tsx
+++ b/src/loader/DocumentLoader.tsx
@@ -11,6 +11,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import Spinner from '../components/Spinner';
 import ThemeContext from '../theme/ThemeContext';
 import PdfJs from '../vendors/PdfJs';
+import { CharacterMap } from '../Viewer';
 import AskForPasswordState from './AskForPasswordState';
 import AskingPassword from './AskingPassword';
 import CompletedState from './CompletedState';
@@ -25,12 +26,13 @@ import WrongPasswordState from './WrongPasswordState';
 export type RenderError = (error: LoadError) => React.ReactElement;
 
 interface DocumentLoaderProps {
+    characterMap?: CharacterMap;
     file: PdfJs.FileData;
     renderError?: RenderError;
     render(doc: PdfJs.PdfDocument): React.ReactElement;
 }
 
-const DocumentLoader: React.FC<DocumentLoaderProps> = ({ file, render, renderError }) => {
+const DocumentLoader: React.FC<DocumentLoaderProps> = ({ characterMap, file, render, renderError }) => {
     const theme = useContext(ThemeContext);
     const [status, setStatus] = useState<LoadingStatus>(new LoadingState(0));
 
@@ -43,8 +45,13 @@ const DocumentLoader: React.FC<DocumentLoaderProps> = ({ file, render, renderErr
         //  This may be caused by an accidental early return statement
         //  ```
         setStatus(new LoadingState(0));
+        const params = Object.assign(
+            {},
+            { url: file },
+            characterMap ? { cMapUrl: characterMap.url, cMapPacked: characterMap.isCompressed } : {}
+        );
 
-        const loadingTask = PdfJs.getDocument(file);
+        const loadingTask = PdfJs.getDocument(params);
         loadingTask.onPassword = (verifyPassword: VerifyPassword, reason: string): void => {
             switch (reason) {
                 case PdfJs.PasswordResponses.NEED_PASSWORD:

--- a/src/print/PrintZone.tsx
+++ b/src/print/PrintZone.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useContext, useEffect, useState } from 'react';
-import ReactDOM, { createPortal } from 'react-dom';
+import { createPortal } from 'react-dom';
 
 import PdfJs from '../vendors/PdfJs';
 import ThemeContext from '../theme/ThemeContext';

--- a/src/vendors/PdfJs.d.ts
+++ b/src/vendors/PdfJs.d.ts
@@ -38,7 +38,12 @@ declare module 'pdfjs-dist' {
         getPage(pageIndex: number): Promise<Page>;
         getPageIndex(ref: OutlineRef): Promise<number>;
     }
-    function getDocument(file: FileData): LoadingTask;
+    interface GetDocumentParams {
+        url: FileData;
+        cMapUrl?: string;
+        cMapPacked?: boolean;
+    }
+    function getDocument(params: GetDocumentParams): LoadingTask;
 
     // Attachment
     interface Attachment {


### PR DESCRIPTION
for #107 

Sample file: https://tcpdf.org/files/examples/example_033.pdf
The viewer downloads the following cmaps:

<img width="564" alt="Screen Shot 2020-06-14 at 17 38 54" src="https://user-images.githubusercontent.com/57786711/84591290-60f8bd00-ae67-11ea-9e7b-1558c9b74fd6.png">
