### PR TITLE
Fix an issue that can't open file from bytes

### DIFF
--- a/src/layouts/Inner.tsx
+++ b/src/layouts/Inner.tsx
@@ -96,7 +96,7 @@ const Inner: React.FC<InnerProps> = ({
             return;
         }
         const selectedFile = files[0];
-        if (getFileExt(file.name).toLowerCase() !== 'pdf') {
+        if (getFileExt(selectedFile.name).toLowerCase() !== 'pdf') {
             return;
         }
         new Promise<Uint8Array>((resolve) => {

--- a/src/loader/DocumentLoader.tsx
+++ b/src/loader/DocumentLoader.tsx
@@ -47,7 +47,7 @@ const DocumentLoader: React.FC<DocumentLoaderProps> = ({ characterMap, file, ren
         setStatus(new LoadingState(0));
         const params = Object.assign(
             {},
-            { url: file },
+            { data: file },
             characterMap ? { cMapUrl: characterMap.url, cMapPacked: characterMap.isCompressed } : {}
         );
 

--- a/src/vendors/PdfJs.d.ts
+++ b/src/vendors/PdfJs.d.ts
@@ -39,7 +39,7 @@ declare module 'pdfjs-dist' {
         getPageIndex(ref: OutlineRef): Promise<number>;
     }
     interface GetDocumentParams {
-        url: FileData;
+        data: FileData;
         cMapUrl?: string;
         cMapPacked?: boolean;
     }


### PR DESCRIPTION
Related to #107 

The open document params are changed if we add `cmap`.